### PR TITLE
Removed duplicate fields and setters from mutation input.

### DIFF
--- a/ent/template/mutation_input.tmpl
+++ b/ent/template/mutation_input.tmpl
@@ -14,7 +14,9 @@
     // {{ $input }} represents a mutation input for creating {{ plural $n.Name | lower }}.
     type {{ $input }} struct {
         {{- range $f := $n.Fields }}
-            {{ $f.StructField }} {{ if and (or $f.Optional $f.Default) (not $f.Type.RType.IsPtr) }}*{{ end }}{{ $f.Type }}
+            {{- if not $f.IsEdgeField }}
+                {{ $f.StructField }} {{ if and (or $f.Optional $f.Default) (not $f.Type.RType.IsPtr) }}*{{ end }}{{ $f.Type }}
+            {{- end }}
         {{- end }}
         {{- range $e := $n.Edges }}
             {{- if $e.Unique }}
@@ -28,12 +30,14 @@
     // Mutate applies the {{ $input }} on the {{ $n.CreateName }} builder.
     func (i *{{ $input }}) Mutate(m *{{ $n.CreateName }}) {
         {{- range $f := $n.Fields }}
-            {{- if or $f.Optional $f.Default }}
-                if v := i.{{ $f.StructField }}; v != nil {
-                    m.{{ $f.MutationSet }}(*v)
-                }
-            {{- else }}
-                m.{{ $f.MutationSet }}(i.{{ $f.StructField }})
+            {{- if not $f.IsEdgeField }}
+                {{- if or $f.Optional $f.Default }}
+                    if v := i.{{ $f.StructField }}; v != nil {
+                        m.{{ $f.MutationSet }}(*v)
+                    }
+                {{- else }}
+                    m.{{ $f.MutationSet }}(i.{{ $f.StructField }})
+                {{- end }}
             {{- end }}
         {{- end }}
         {{- range $e := $n.Edges }}


### PR DESCRIPTION
Previously, any edge that used an existing field would double generate the fields on the generated `CreateInput` type and setters in the `Mutate` method. This changes removes the ones created for the FK field and keeps the ones generated for the edge.

Since there were two setters before this change, and they are both always called, if the input was instantiated using the field generated from the schema field instead of the schema edge, the setter in the mutation method generated for the edge would be called second, always setting the value back to zero.

The mutation method would contain something like the following, where an `organization_id` field exists to hold the FK and the `organization` edge references it:

~~~go
func (i *CreateProjectInput) Mutate(m *ProjectCreate) {
	// ...
	m.SetOrganizationID(i.OrganizationID)
	m.SetOrganizationID(i.Organization)
	// ...
}
~~~